### PR TITLE
Fix hardcoded value in GA template

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,7 +37,7 @@ github_repo: "mkdocs-jekyll"
 twitter: vsoch
 linkedin: vsochat
 dockerhub: vanessa
-# google-analytics: UA-XXXXXXXXXX
+# google-analytics: G-XXXXXXXXXX
 # Image and (square) dimension for logo (don't start with /)
 # If commented, will use material hat theme
 # logo: "assets/img/logo/SRCC-square-red.png"

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,4 +1,4 @@
-{% if site.google-analytics %}<script async src="https://www.googletagmanager.com/gtag/js?id=UA-143467500-1"></script>
+{% if site.google-analytics %}<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google-analytics }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
Beware that Universal Analytics is now deprecated in favor of Google Analytics 4. Hopefully the JS snippet remains the same.

See https://support.google.com/analytics/answer/11583528