### PR TITLE
Fix: move GA4 script call to head element

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,5 @@
 <head>
+  {% include google-analytics.html %}
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta http-equiv="content-language" content="en">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,6 +19,5 @@
     {% include headers.html %}
     {% include tags.html %}
     {% include scrolltop.html %}
-    {% include google-analytics.html %}
   </body>
 </html>


### PR DESCRIPTION
Hi,

I moved the GA4 script call from end of body element to the beginning head element to comply with Google recommandations and especially to make it work. Without this change, the GA4 site cannot find the GA id on the site.